### PR TITLE
Bump version for PyPI publishing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='ceffyl',
-    version='1.26',
+    version='1.27',
     description=('Software to rapidly and flexibly analyse Pulsar Timing ' +
                  'Array data via the Generalised Factorised Likelihood (GFL)' +
                  'method'),


### PR DESCRIPTION
Bump version from 1.26 to 1.27 so that we can publish the package with updated requirements to PyPI