### PR TITLE
fixed psd initialisation bug

### DIFF
--- a/ceffyl/Ceffyl.py
+++ b/ceffyl/Ceffyl.py
@@ -453,7 +453,7 @@ class ceffyl():
         """
 
         # initalise array of rho values with lower prior boundary
-        rho = np.ones((self.N_psrs, self.N_freqs)) * 10**(2*self.rho_grid[0])
+        rho = np.zeros((self.N_psrs, self.N_freqs))
         for s in self.signals:  # iterate through signals
             # reshape array to vectorise to size (N_kwargs, N_sig_psrs)
             mapped_xs = {s_i.name: xs[p]


### PR DESCRIPTION
An array of `rho` was initialised at the lower free spectrum prior boundary. This is a mistake because it results in some numerical inaccuracies, especially close to the boundary.

Now initialise an array of zeros