### PR TITLE
Update github packaging action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,11 @@ on:
     types: [published]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -12,14 +16,12 @@ jobs:
         with:
           python-version: 3.11
 
-      - run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade build
-          python3 -m build
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.2
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./dist
+          path: ./wheelhouse/*.whl
 
   pypi-publish:
     needs: ['build']


### PR DESCRIPTION
Updated the GitHub action to use `cibuildwheel`. This should fix the incompatible tags issue, and it should give us
 MacOS builds.