### PR TITLE
HOTFIX - grouping bug fix, linting

### DIFF
--- a/ceffyl/Ceffyl.py
+++ b/ceffyl/Ceffyl.py
@@ -352,16 +352,18 @@ class ceffyl():
                 # if binmid is None:
                 for ii, p in enumerate(s.params):
                     if p.size is None or p.size == 1:
-                        posterior_samples = [s.psd_priors[ii].sample()
-                                             for jj in
-                                             range(nested_posterior_sample_size)]
+                        posterior_samples = [
+                            s.psd_priors[ii].sample() for jj in
+                            range(nested_posterior_sample_size)
+                            ]
                         hist, bin_edges = np.histogram(posterior_samples,
                                                        bins='fd')
                         hist_cumulative.append(np.cumsum(hist/hist.sum()))
                         binmid.append((bin_edges[:-1] + bin_edges[1:])/2)
                     else:
                         # FIX ME: nested sampling for free spec irn
-                        print('Free spectrum not supported with nested sampling yet!')
+                        print('Free spectrum not supported with nested ' +
+                              'sampling yet!')
                         hist_cumulative, binmid = None, None
 
             self.hist_cumulative = hist_cumulative
@@ -431,7 +433,7 @@ class ceffyl():
                                  self.binmid[ii])
 
         return x
-    
+
     def hypercube(self, xs):
         """
         function to compute ppf of the prior to use in nested sampling
@@ -459,7 +461,8 @@ class ceffyl():
         """
 
         # initalise array of rho values with lower prior boundary
-        red_rho, cp_rho = np.zeros((self.N_psrs, self.N_freqs)), np.zeros((self.N_psrs, self.N_freqs))
+        red_rho = np.zeros((self.N_psrs, self.N_freqs))
+        cp_rho = np.zeros((self.N_psrs, self.N_freqs))
         for s in self.red_signals:  # iterate through signals
             # reshape array to vectorise to size (N_kwargs, N_sig_psrs)
             mapped_xs = {s_i.name: xs[p]
@@ -484,8 +487,8 @@ class ceffyl():
 
         if (idx >= self.rho_grid.shape[0]).any():
             return -np.inf
-        
-        idx[idx < 0] = 0  # if spectrum less than logrho, set to bottom boundary
+
+        idx[idx < 0] = 0  # if spectrum less than logrho, set to lower boundary
 
         logpdf = self.density[self._I, self._J, idx]  # logpdf of rho values
 

--- a/ceffyl/Sampler.py
+++ b/ceffyl/Sampler.py
@@ -104,15 +104,15 @@ class JumpProposal(object):
 
                     # no need to extend if hist edges are already prior min/max
                     if isinstance(emp_dist, EmpiricalDistribution2D):
-                        if not(emp_dist._edges[ii][0] == prior_min and
-                               emp_dist._edges[ii][-1] == prior_max):
+                        if not (emp_dist._edges[ii][0] == prior_min and
+                                emp_dist._edges[ii][-1] == prior_max):
 
                             prior_ok = False
                             continue
 
                     elif isinstance(emp_dist, EmpiricalDistribution2DKDE):
-                        if not(emp_dist.minvals[ii] == prior_min and
-                               emp_dist.maxvals[ii] == prior_max):
+                        if not (emp_dist.minvals[ii] == prior_min and
+                                emp_dist.maxvals[ii] == prior_max):
 
                             prior_ok = False
                             continue
@@ -319,9 +319,9 @@ class JumpProposal(object):
         lqxy = 0
 
         # randomly choose parameter
-        #p_name = np.random.choice(self.gw_names)
-        #pidx = self.param_names.index(p_name)
-        #p = self.params[pidx]
+        # p_name = np.random.choice(self.gw_names)
+        # pidx = self.param_names.index(p_name)
+        # p = self.params[pidx]
 
         p = np.random.choice(self.params)
         pidx = self.params.index(p)
@@ -438,19 +438,20 @@ def setup_sampler(ceffyl, outdir, logL, logp, resume=True, jump=True,
 
         # make a group for each signal, with all non-global parameters
         for s in ceffyl.signals:
-            groups.extend(s.pmap)
+            groups.append(list(np.hstack(s.pmap)))
 
             if s.CP:  # visit GW signals x5 more often
-                [groups.extend(s.pmap) for ii in range(5)]
-        
+                [groups.append(list(np.hstack(s.pmap))) for ii in range(4)]
+
         # make a group for each pulsar
         for p in ceffyl.pulsar_list:
-            groups.append([ceffyl.param_names.index(pn) for pn in
-                           ceffyl.param_names if p in pn])
-        
+            if p != 'freespec':
+                groups.append([ceffyl.param_names.index(pn) for pn in
+                               ceffyl.param_names if p in pn])
+
         # group gw parameters
         groups.extend([[ceffyl.param_names.index(pn) for pn in
-                        ceffyl.param_names if 'gw' in pn]]*10)
+                        ceffyl.param_names if 'gw' in pn]]*5)
 
     # sampler
     sampler = ptmcmc(ceffyl.ndim, logL, logp, cov,
@@ -482,7 +483,7 @@ def setup_sampler(ceffyl, outdir, logL, logp, resume=True, jump=True,
         # Red noise prior draw
         if red_noise:
             print('Adding red noise prior draws...\n')
-            sampler.addProposalToCycle(jp.draw_from_red_prior, 50)
+            sampler.addProposalToCycle(jp.draw_from_red_prior, 10)
 
         # GWB uniform distribution draw
         if gw_signal:


### PR DESCRIPTION
A bug in `Sampler.py` resulted in a empty grouping of parameters. In addition, single parameters were being grouped rather than pairs or more than two parameters.

This resulted in some errors when running PTMCMC as well as reading the output file. However, it shouldn't have affected sampling performance.

This issue was first raised in `PTArcade` [PR #47](https://github.com/andrea-mitridate/PTArcade/pull/47) by @davecwright3 