### PR TITLE
fix(CI): add pyproject fields to fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy>=1.23.5,<2.0.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name='ceffyl'
+version='1.41'


### PR DESCRIPTION
This should fix the failing PyPI publishing action.

![image](https://github.com/user-attachments/assets/b679446e-b88f-4dba-8d0f-ee749bbaf484)
