### PR TITLE
fix: numpy 2.0 compatibility

### DIFF
--- a/ceffyl/Ceffyl.py
+++ b/ceffyl/Ceffyl.py
@@ -227,7 +227,7 @@ class ceffyl():
         self.reshaped_freqs = self.freqs.reshape((1, self.N_freqs)).T
         self.Tspan = 1/self.freqs[0] if Tspan is None else Tspan
         self.rho_labels = np.loadtxt(f'{datadir}/log10rholabels.txt',
-                                     dtype=np.unicode_, ndmin=1)
+                                     dtype=np.str_, ndmin=1)
 
         # storing grid point information
         rho_grid = np.load(f'{datadir}/log10rhogrid.npy')
@@ -239,14 +239,14 @@ class ceffyl():
         # selected pulsars
         if pulsar_list is None:
             self.pulsar_list = list(np.loadtxt(f'{datadir}/pulsar_list.txt',
-                                               dtype=np.unicode_, ndmin=1))
+                                               dtype=np.str_, ndmin=1))
         else:
             self.pulsar_list = pulsar_list
         self.N_psrs = len(self.pulsar_list)
 
         # find index of sublist
         file_psrs = list(np.loadtxt(f'{datadir}/pulsar_list.txt',
-                                    dtype=np.unicode_, ndmin=1))
+                                    dtype=np.str_, ndmin=1))
         selected_psrs = [file_psrs.index(p) for p in self.pulsar_list]
 
         # load densities from npy binary file for given psrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "KDEpy>=1.1.0,<2.0.0",
     "la_forge>=1.1.0,<2.0.0",
     "natsort>=8.4.0,<9.0.0",
+    "numpy>=1.23.5,<3.0.0",
     "PTMCMCSampler>=2.1.2,<3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "numpy>=1.23.5,<2.0.0"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
- Removes unnecessary build requirements now that we don't have to compile any C
- Adds NumPy to runtime dependencies
- Switched from `np.unicode_` to `np.str_`. It was an alias of `str_` to begin with, and was deprecated in NumPy 2.0. This change is backward compatible with earlier NumPy versions.

The rest of the code-base was checked for NumPy 2.0 compatibility issues with

`ruff check --select="NPY201"` 

and passed.